### PR TITLE
Add explicit slugs

### DIFF
--- a/rose-pine-dawn.yaml
+++ b/rose-pine-dawn.yaml
@@ -1,5 +1,6 @@
 scheme: "Rosé Pine Dawn"
 author: "Emilia Dunfelt <edun@dunfelt.se>"
+slug: "rose-pine-dawn"
 base00: "faf4ed"
 base01: "fffaf3"
 base02: "f2e9de"

--- a/rose-pine-moon.yaml
+++ b/rose-pine-moon.yaml
@@ -1,5 +1,6 @@
 scheme: "Rosé Pine Moon"
 author: "Emilia Dunfelt <edun@dunfelt.se>"
+slug: "rose-pine-moon"
 base00: "232136"
 base01: "2a273f"
 base02: "393552"

--- a/rose-pine.yaml
+++ b/rose-pine.yaml
@@ -1,5 +1,6 @@
 scheme: "Rosé Pine"
 author: "Emilia Dunfelt <edun@dunfelt.se>"
+slug: "rose-pine"
 base00: "191724"
 base01: "1f1d2e"
 base02: "26233a"


### PR DESCRIPTION
The builder base16 spec allows for explicitly defining slugs. Because of the accent in "Rose", the slugified name ends up as "ros-pine" which is counter-intuitive, and leads to unexpected bugs when using the schemes in scripting. This commit simply adds explicit slugs to avoid this.

This does introduce breaking changes for anything depending on the slug to be "ros-pine".